### PR TITLE
Couple of tweaks

### DIFF
--- a/ecs/ecs-cluster.yaml
+++ b/ecs/ecs-cluster.yaml
@@ -114,6 +114,10 @@ Resources:
 
   Cluster:
     Type: AWS::ECS::Cluster
+    Properties:
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
 
 Outputs:
   ALB:

--- a/ecs/pipeline.yaml
+++ b/ecs/pipeline.yaml
@@ -44,7 +44,7 @@ Resources:
         EnvironmentVariables:
           - Name: REPOSITORY_URI
             Type: PLAINTEXT
-            Value: !Select [0, !Split [':', !Ref FrontendImageUri]]
+            Value: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ECRRepository}"
         Image: aws/codebuild/standard:1.0
         PrivilegedMode: true
         Type: LINUX_CONTAINER

--- a/ecs/pipeline.yaml
+++ b/ecs/pipeline.yaml
@@ -114,6 +114,7 @@ Resources:
               Configuration:
                 RepositoryName: !GetAtt CodeCommitRepository.Name
                 BranchName: master
+                PollForSourceChanges: false
               OutputArtifacts:
                 - Name: Source
         - Name: Build


### PR DESCRIPTION
- `PollForSourceChanges` to not have pipeline running twice as the default trigger mechanism is through Eventbridge upon new commits to CodeCommit.
- Push new docker tags to ECR repository created by CF template as right now it is trying to push to the default repo to pull initial images from.
- Enabled Container Insights in ECS cluster which is handy to demo Container Insights using this repo. 